### PR TITLE
update and fix

### DIFF
--- a/gnustyle_setup.sh
+++ b/gnustyle_setup.sh
@@ -3,7 +3,7 @@ touch NEWS README AUTHORS ChangeLog
 cat <<EOF > COPYING
 MIT License
 
-Copyright (c) 2023 A5size
+Copyright (c) $(date +%Y) A5size
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -35,18 +35,19 @@ echo SUBDIRS=src >> Makefile.am
 cat <<EOF > src/Makefile.am
 bin_PROGRAMS=praparat_builder praparat_gui praparat_deb praparat_cui
 IMGUI_DIR = ./imgui
-praparat_builder_SOURCES=builder.cpp \$(IMGUI_DIR)/imgui.cpp \$(IMGUI_DIR)/imgui_demo.cpp \$(IMGUI_DIR)/imgui_draw.cpp \$(IMGUI_DIR)/imgui_tables.cpp \$(IMGUI_DIR)/imgui_widgets.cpp \$(IMGUI_DIR)/backends/imgui_impl_glfw.cpp \$(IMGUI_DIR)/backends/imgui_impl_opengl2.cpp lib/ImGuiFileDialog/ImGuiFileDialog.cpp  \$(IMGUI_DIR)imconfig.h  \$(IMGUI_DIR)imgui_internal.h  \$(IMGUI_DIR)imstb_textedit.h \$(IMGUI_DIR)imgui.h \$(IMGUI_DIR)imstb_rectpack.h  \$(IMGUI_DIR)imstb_truetype.h
-praparat_gui_SOURCES=gui.cpp math.f90 praparat.f90 \$(IMGUI_DIR)/imgui.cpp \$(IMGUI_DIR)/imgui_demo.cpp \$(IMGUI_DIR)/imgui_draw.cpp \$(IMGUI_DIR)/imgui_tables.cpp \$(IMGUI_DIR)/imgui_widgets.cpp \$(IMGUI_DIR)/backends/imgui_impl_glfw.cpp \$(IMGUI_DIR)/backends/imgui_impl_opengl2.cpp \$(IMGUI_DIR)imconfig.h  \$(IMGUI_DIR)imgui_internal.h  \$(IMGUI_DIR)imstb_textedit.h \$(IMGUI_DIR)imgui.h \$(IMGUI_DIR)imstb_rectpack.h  \$(IMGUI_DIR)imstb_truetype.h lib/ImGuiFileDialog/ImGuiFileDialog.cpp lib/ImGuiFileDialog/ImGuiFileDialog.h lib/ImGuiFileDialog/ImGuiFileDialogConfig.h
-praparat_gui_FFLAGS = -Wall -fbounds-check -O0 -Wuninitialized -fbacktrace -g
+praparat_builder_SOURCES=builder.cpp \$(IMGUI_DIR)/imgui.cpp \$(IMGUI_DIR)/imgui_demo.cpp \$(IMGUI_DIR)/imgui_draw.cpp \$(IMGUI_DIR)/imgui_tables.cpp \$(IMGUI_DIR)/imgui_widgets.cpp \$(IMGUI_DIR)/backends/imgui_impl_glfw.cpp \$(IMGUI_DIR)/backends/imgui_impl_opengl2.cpp lib/ImGuiFileDialog/ImGuiFileDialog.cpp  \$(IMGUI_DIR)imconfig.h  \$(IMGUI_DIR)imgui_internal.h  \$(IMGUI_DIR)imstb_textedit.h \$(IMGUI_DIR)imgui.h \$(IMGUI_DIR)imstb_rectpack.h  \$(IMGUI_DIR)imstb_truetype.h \$(IMGUI_DIR)backends/imgui_impl_glfw.h \$(IMGUI_DIR)backends/imgui_opengl2_glfw.h
+praparat_gui_SOURCES=gui.cpp math.f90 praparat.f90 \$(IMGUI_DIR)/imgui.cpp \$(IMGUI_DIR)/imgui_demo.cpp \$(IMGUI_DIR)/imgui_draw.cpp \$(IMGUI_DIR)/imgui_tables.cpp \$(IMGUI_DIR)/imgui_widgets.cpp \$(IMGUI_DIR)/backends/imgui_impl_glfw.cpp \$(IMGUI_DIR)/backends/imgui_impl_opengl2.cpp \$(IMGUI_DIR)imconfig.h  \$(IMGUI_DIR)imgui_internal.h  \$(IMGUI_DIR)imstb_textedit.h \$(IMGUI_DIR)imgui.h \$(IMGUI_DIR)imstb_rectpack.h  \$(IMGUI_DIR)imstb_truetype.h lib/ImGuiFileDialog/ImGuiFileDialog.cpp lib/ImGuiFileDialog/ImGuiFileDialog.h lib/ImGuiFileDialog/ImGuiFileDialogConfig.h \$(IMGUI_DIR)backends/imgui_impl_glfw.h \$(IMGUI_DIR)backends/imgui_opengl2_glfw.h
+praparat_gui_FFLAGS = -O2 -cpp
 praparat_deb_SOURCES=math.f90 praparat.f90 main.f90
-praparat_deb_FFLAGS =-Wall -fbounds-check -O0 -Wuninitialized -fbacktrace -g
+praparat_deb_FFLAGS =-Wall -fbounds-check -O0 -Wuninitialized -fbacktrace -g -cpp
 praparat_cui_SOURCES=math.f90 praparat.f90 main.f90
+praparat_cui_FFLAGS = -O2 -cpp
 praparat_SOURCES_FFLAGS=-O3
 CXXFLAGS = -std=c++17 -I\$(IMGUI_DIR) -I\$(IMGUI_DIR)/backends -Wall -Wformat -Wall -fbounds-check -O0 -Wuninitialized -g
 EOF
 aclocal
 autoheader
 autoconf
-autoupdate
 automake --add-missing --copy --force-missing
+autoreconf -fiv
 echo "please! ./configure && make!"


### PR DESCRIPTION
すみません何度も…このコミットでmsys2環境とLinuxでは成功したので修正版挙げさせて貰います。


以下は成功時手順
msys2環境
```
 pacman -S automake autoconf make autotools mingw-w64-x86_64-glfw mingw-w64-x86_64-gcc mingw-w64-x86_64-gcc-fortran mingw-w64-x86_64-gcc-libgfortran
```
の後mingw64を起動して./gnustyle_setup.shの後./configureをしてcd src && makeでビルドの成功を確認しました。

自分の環境での成功もいちよう挙げときます。
NixOS環境/nix
```sh
cat <<EOF  > shell.nix
{ pkgs ? import <nixpkgs> {} }:
with pkgs;
pkgs.mkShell {
  name = "OpenPraparat";
  buildInputs = [ pkgs.freeglut pkgs.vulkan-headers gfortran xorg.libXdmcp  pkgs.xorg_sys_opengl pkgs.glfw3 pkgs.glui pkgs.gl3w pkgs.mesa_glu (pkgs.gcc11.cc.override {langFortran=true; langCC=true;langC=true;}) pkgs.cmake pkgs.gtk2 pkgs.pkg-config pkgs.automake pkgs.autoconf pkgs.autobuild];
}
EOF
nix-shell shell.nix
git clone https://github.com/nodokaha/OpenPraparat -b fix_automake
cd OpenPraparat && ./gnustyle_setup.sh
./configure
cd src && make
```