### PR TITLE
Releaseページ自動生成

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,103 @@
+name: Makefile CI
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  create_release:
+    name: Create release
+    runs-on: ubuntu-latest
+    # Note this. We are going to use that in further jobs.
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+    steps:
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+        
+  build:
+    name: release_assets
+    needs: create_release
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup Ubuntu
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: |
+        sudo apt install build-essential gfortran
+        sudo apt install libglu1-mesa-dev mesa-common-dev
+        sudo apt install libglfw3 libglfw3-dev
+        
+    - name: Setup Windows
+      if: ${{ matrix.os == 'windows-latest' }}
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW64
+      
+    - name: Setup MSYS2
+      if: ${{ matrix.os == 'windows-latest' }}
+      shell: msys2 {0}
+      run: |
+        echo y|pacman -Sy
+        echo y|pacman -Su
+
+        echo y|pacman -S mingw-w64-x86_64-gcc
+        echo y|pacman -S make
+        echo y|pacman -S zip
+        echo y|pacman -S mingw-w64-x86_64-pkg-config
+        echo y|pacman -S mingw-w64-x86_64-glfw
+        echo y|pacman -S mingw-w64-x86_64-gcc-fortran
+        echo y|pacman -S mingw-w64-x86_64-gcc-libgfortran
+        cd src
+        make all install
+      
+    - name: Setup Environment Mac
+      if: ${{ matrix.os == 'macos-latest' }}
+      run: |
+        brew install glfw3 zip gfortran
+        
+    - name: package make
+      if: ${{ matrix.os != 'windows-latest' }}
+      run: |
+        cd src
+        make all install
+      
+    - name: package make on windows binary
+      if: ${{ matrix.os == 'windows-latest' }}
+      shell: msys2 {0}
+      run: |
+        cd src
+        ./link4win.sh
+        cd ..
+        zip -r OpenPraparat.zip build
+        
+    - name: zip
+      if: ${{ matrix.os != 'windows-latest' }}
+      run: zip -r OpenPraparat.zip build
+        
+    - name: Upload Release Asset
+      if: always()
+      id: upload-release-asset 
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.create_release.outputs.upload_url }} 
+        asset_path: OpenPraparat.zip
+        asset_name: OpenPraparat-${{ matrix.os }}
+        asset_content_type: application/zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,21 +48,20 @@ jobs:
       uses: msys2/setup-msys2@v2
       with:
         msystem: MINGW64
+        update: true
+        install: >-
+          mingw-w64-x86_64-gcc
+          make
+          zip
+          mingw-w64-x86_64-pkg-config
+          mingw-w64-x86_64-glfw
+          mingw-w64-x86_64-gcc-fortran
+          mingw-w64-x86_64-gcc-libgfortran
       
-    - name: Setup MSYS2
+    - name: package make on windows
       if: ${{ matrix.os == 'windows-latest' }}
       shell: msys2 {0}
       run: |
-        echo y|pacman -Sy
-        echo y|pacman -Su
-
-        echo y|pacman -S mingw-w64-x86_64-gcc
-        echo y|pacman -S make
-        echo y|pacman -S zip
-        echo y|pacman -S mingw-w64-x86_64-pkg-config
-        echo y|pacman -S mingw-w64-x86_64-glfw
-        echo y|pacman -S mingw-w64-x86_64-gcc-fortran
-        echo y|pacman -S mingw-w64-x86_64-gcc-libgfortran
         cd src
         make all install
       
@@ -71,13 +70,17 @@ jobs:
       run: |
         brew install glfw3 zip gfortran
         
-    - name: package make
-      if: ${{ matrix.os != 'windows-latest' }}
+    - name: package make on linux
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
+        mkdir build
+        ./gnustyle_setup.sh
+        ./configure --prefix=/ --disable-shared --enable-static LDFLAGS="-static-libgcc -static-libstdc++ -static-libgfortran -Bstatic -lglfw"
         cd src
-        make all install
+        make
+        make install DESTDIR=$(pwd)/../build
       
-    - name: package make on windows binary
+    - name: package link on windows binary
       if: ${{ matrix.os == 'windows-latest' }}
       shell: msys2 {0}
       run: |
@@ -85,6 +88,12 @@ jobs:
         ./link4win.sh
         cd ..
         zip -r OpenPraparat.zip build
+        
+    - name: package make on mac
+      if: ${{ matrix.os == 'macos-latest' }}
+      run: |
+        cd src
+        make all install
         
     - name: zip
       if: ${{ matrix.os != 'windows-latest' }}
@@ -99,5 +108,5 @@ jobs:
       with:
         upload_url: ${{ needs.create_release.outputs.upload_url }} 
         asset_path: OpenPraparat.zip
-        asset_name: OpenPraparat-${{ matrix.os }}
+        asset_name: OpenPraparat-${{ runner.os }}-${{ github.ref_name }}.zip
         asset_content_type: application/zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
       run: |
         mkdir build
         ./gnustyle_setup.sh
-        ./configure --prefix=/ --disable-shared --enable-static LDFLAGS="-static-libgcc -static-libstdc++ -static-libgfortran -Bstatic -lglfw"
+        ./configure --prefix=/ --disable-shared --enable-static LDFLAGS="-static-libgcc -static-libstdc++ -static-libgfortran"
         cd src
         make
         make install DESTDIR=$(pwd)/../build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # OpenPraparat
-[![Makefile CI](https://github.com/nodokaha/OpenPraparat/actions/workflows/main.yml/badge.svg)](https://github.com/nodokaha/OpenPraparat/actions/workflows/main.yml)
+[![Makefile CI](https://github.com/A5size/OpenPraparat/actions/workflows/main.yml/badge.svg)](https://github.com/A5size/OpenPraparat/actions/workflows/main.yml)
 
 OpenPraparat is a code that simulates an artificial life model presented in the paper titled "Artificial Life using a Book and Bookmarker." 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # OpenPraparat
+[![Makefile CI](https://github.com/nodokaha/OpenPraparat/actions/workflows/main.yml/badge.svg)](https://github.com/nodokaha/OpenPraparat/actions/workflows/main.yml)
 
 OpenPraparat is a code that simulates an artificial life model presented in the paper titled "Artificial Life using a Book and Bookmarker." 
 

--- a/gnustyle_setup.sh
+++ b/gnustyle_setup.sh
@@ -27,7 +27,11 @@ autoscan
 sed -e "s/FULL-PACKAGE-NAME/OpenPraparat/" -i configure.scan
 sed -e "s/VERSION/0.0.1-beta/" -i configure.scan
 sed -e "13aAC_PROG_FC" -i configure.scan
-sed -e "15aAM_INIT_AUTOMAKE" -i configure.scan
+sed -e "15aAM_INIT_AUTOMAKE([subdir-objects])" -i configure.scan
+sed -e "15aLT_INIT([disable-shared])" -i configure.scan
+sed -e "15aAC_PROG_LIBTOOL" -i configure.scan
+sed -e "15aAM_PROG_AR" -i configure.scan
+sed -e "15aAC_SUBST(LIBTOOL_DEPS)" -i configure.scan
 sed -e "17a# FIXME: Replace 'main' with a function in '-lquadmath':\nAC_CHECK_LIB([quadmath], [main])\n# FIXME: Replace 'main' with a function in '-lGL':\nAC_CHECK_LIB([GL], [main])\n# FIXME: Replace 'main' with a function in '-lGLU':\nAC_CHECK_LIB([GLU], [main])\n# FIXME: Replace 'main' with a function in '-lgdi32':\nAC_CHECK_LIB([gdi32], [main])\n# FIXME: Replace 'main' with a function in '-lgfortran':\nAC_CHECK_LIB([gfortran], [main])\n# FIXME: Replace 'main' with a function in '-lglfw':\nAC_CHECK_LIB([glfw], [main])\n# FIXME: Replace 'main' with a function in '-lglfw3':\nAC_CHECK_LIB([glfw3], [main])\n# FIXME: Replace 'main' with a function in '-limm32':\nAC_CHECK_LIB([imm32], [main])\n# FIXME: Replace 'main' with a function in '-lopengl32':\nAC_CHECK_LIB([opengl32], [main])\n# FIXME: Replace 'main' with a function in '-lpthread':\nAC_CHECK_LIB([pthread], [main])" -i configure.scan
 #sed -e "s/src\/Makefile/Makefile src\/Makefile/" -i configure.scan
 mv configure.scan configure.ac

--- a/src/Makefile
+++ b/src/Makefile
@@ -52,7 +52,7 @@ LIBS =
 
 ifeq ($(UNAME_S), Linux) #LINUX
 	ECHO_MESSAGE = "Linux"
-	LIBS += -lGL -lGLU `pkg-config --static --libs glfw3`
+	LIBS += -lGL -lGLU `pkg-config --libs glfw3`
 
 	CXXFLAGS += `pkg-config --cflags glfw3`
 	CFLAGS = $(CXXFLAGS)
@@ -64,6 +64,9 @@ ifeq ($(UNAME_S), Darwin) #APPLE
 	BREW_GCC_PATH := $(shell brew --prefix gcc)
 	BREW_GCC := $(shell ls -1 $(BREW_GCC_PATH)/bin/ | grep ^g++ | sed 's/*//')
 	CXX = $(BREW_GCC)
+	BREW_FC_PATH := $(shell brew --prefix gfortran)
+	BREW_FC := $(shell ls -1 $(BREW_FC_PATH)/bin/ | grep ^gfortran | sed -e 's/*//' -e 's/gfortran //')
+	FC = $(BREW_FC)
 
 	LIBS += -framework OpenGL -framework Cocoa -framework IOKit -framework CoreVideo
 	LIBS += -L/usr/local/lib -L/opt/homebrew/lib

--- a/src/Makefile
+++ b/src/Makefile
@@ -65,7 +65,7 @@ ifeq ($(UNAME_S), Darwin) #APPLE
 	BREW_GCC := $(shell ls -1 $(BREW_GCC_PATH)/bin/ | grep ^g++ | sed 's/*//')
 	CXX = $(BREW_GCC)
 	BREW_FC_PATH := $(shell brew --prefix gfortran)
-	BREW_FC := $(shell ls -1 $(BREW_FC_PATH)/bin/ | grep ^gfortran | sed -e 's/*//' -e 's/gfortran //')
+	BREW_FC := $(shell ls -1 $(BREW_FC_PATH)/bin/ | grep ^gfortran- | sed -e 's/*//')
 	FC = $(BREW_FC)
 
 	LIBS += -framework OpenGL -framework Cocoa -framework IOKit -framework CoreVideo


### PR DESCRIPTION
このプルリクエストをマージしてこの記事の通りに権限を与えればタグから自動でリリースページを作ってくれます
[https://qiita.com/Hiroki_lzh/items...](https://qiita.com/Hiroki_lzh/items/3607072052a2de7e8378#%E3%81%BE%E3%81%9A%E3%81%AFactions%E5%85%A8%E4%BD%93%E3%81%A7%E6%9B%B8%E3%81%8D%E8%BE%BC%E3%81%BF%E6%A8%A9%E9%99%90%E3%82%92%E3%82%82%E3%82%89%E3%81%88)
その後
```
git tag v0.0.1-beta
git gush --tags
```
などでタグをプッシュすることでリリースページが自動的に生成されます
現状ではタグをつけると全部リリースページ生成のスクリプトが走っちゃうのでお気を付けください
またLinuxはgfortranのスタティックリンクはできましたが、glfw3とquadmathはできなかったのでユーザーに各自インストールしてもらわないといけないのと、MacOSの方は全部依存関係が残っている状況です
引き続き方法がないかちょっと調査してみます
windowsの動作確認はできました